### PR TITLE
Suppress /aliyun_sdk.log

### DIFF
--- a/lib/fluent/plugin/out_oss.rb
+++ b/lib/fluent/plugin/out_oss.rb
@@ -57,6 +57,7 @@ module Fluent
 
     def start
       super
+      Aliyun::Common::Logging.set_log_file('/dev/null')
       @client = Aliyun::OSS::Client.new(
         :endpoint => @oss_endpoint,
         :access_key_id => @oss_key_id,


### PR DESCRIPTION
Firstly, thank you for nice plugin.

Issue type
---

Feature request

What problem does this feature solve?
---

I want to use this plugin with [td-agent](https://www.fluentd.org/download) .
but I got the following error. so I made a bit fix there.

`td-agent` is running as a `td-agent` user.
but [aliyun/common/logging.rb](https://github.com/aliyun/aliyun-oss-ruby-sdk/blob/master/lib/aliyun/common/logging.rb#L14) fails trying to create `/aliyun_sdk.log` on root volume.

Version: 
---

- OS: CentOS 6.x
- td-agent-2.3.6-0.el6.x86_64
- td-agent-gem list
```
fluent-plugin-oss (0.0.1)
aliyun-sdk (0.7.0)
```

Steps to reproduce
---

1. Install td-agent
    ```shell
    sudo yum install td-agent
    cat /etc/td-agent/conf.d/aliyun_oss.conf
    <match **>
    @type oss
    oss_key_id xxx
    oss_key_secret xxx
    oss_bucket xxx
    oss_endpoint xxx
    oss_object_key_format "%{time_slice}/%{host}-%{uuid}.%{file_ext}"

    buffer_path /var/tmp/td-agent/aliyun_oss.buf
    buffer_chunk_limit 256m
    time_slice_format %Y%m%d
    time_slice_wait 10m
    num_threads 8
    log_level error
    </match>

    sudo service td-agent restart
    ```

1. got error.
    <details>

    <summary>/var/log/td-agent/td-agent.log</summary>

    ```shell
    2019-03-05 03:19:41 +0000 [error]: unexpected error error_class=Errno::EACCES error=#<Errno::EACCES: Permission denied @ rb_sysopen - ./aliyun_sdk.log>
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/logger.rb:600:in `initialize'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/logger.rb:600:in `open'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/logger.rb:600:in `create_logfile'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/logger.rb:594:in `rescue in open_logfile'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/logger.rb:591:in `open_logfile'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/logger.rb:549:in `initialize'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/logger.rb:318:in `new'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/2.1.0/logger.rb:318:in `initialize'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aliyun-sdk-0.7.0/lib/aliyun/common/logging.rb:37:in `new'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aliyun-sdk-0.7.0/lib/aliyun/common/logging.rb:37:in `logger'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aliyun-sdk-0.7.0/lib/aliyun/common/logging.rb:30:in `logger'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aliyun-sdk-0.7.0/lib/aliyun/oss/protocol.rb:137:in `get_bucket_acl'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/aliyun-sdk-0.7.0/lib/aliyun/oss/client.rb:90:in `bucket_exists?'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluent-plugin-oss-0.0.1/lib/fluent/plugin/out_oss.rb:66:in `start'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/agent.rb:71:in `block in start'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/agent.rb:70:in `each'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/agent.rb:70:in `start'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/root_agent.rb:108:in `start'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/engine.rb:237:in `start'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/engine.rb:187:in `run'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/supervisor.rb:570:in `run_engine'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/supervisor.rb:162:in `block in start'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/supervisor.rb:366:in `call'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/supervisor.rb:366:in `main_process'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/supervisor.rb:339:in `block in supervise'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/supervisor.rb:338:in `fork'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/supervisor.rb:338:in `supervise'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/supervisor.rb:156:in `start'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/lib/fluent/command/fluentd.rb:173:in `<top (required)>'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/site_ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/lib/ruby/gems/2.1.0/gems/fluentd-0.12.40/bin/fluentd:5:in `<top (required)>'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/bin/fluentd:23:in `load'
    2019-03-05 03:19:41 +0000 [error]: /opt/td-agent/embedded/bin/fluentd:23:in `<top (required)>'
    2019-03-05 03:19:41 +0000 [error]: /usr/sbin/td-agent:7:in `load'
    2019-03-05 03:19:41 +0000 [error]: /usr/sbin/td-agent:7:in `<main>'
    2019-03-05 03:19:41 +0000 [info]: shutting down fluentd
    2019-03-05 03:19:41 +0000 [info]: process finished code=0
    2019-03-05 03:19:41 +0000 [warn]: process died within 1 second. exit.
    ```

    </details>
